### PR TITLE
Add convenience functions to Pack that set 'type' appropriately

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -205,3 +205,10 @@ function typeToMode (type, mode) {
   if (type === 'fifo') value = constants.S_IFIFO
   return (value || (constants.S_IFMT & mode)) | (MASK & mode)
 }
+
+['file', 'directory', 'symlink', 'socket', 'fifo'].forEach(function (type) {
+  Pack.prototype[type] = function (header, buffer, callback) {
+    header.type = type
+    return this.entry(header, buffer, callback)
+  }
+})

--- a/test/pack.js
+++ b/test/pack.js
@@ -108,7 +108,9 @@ module.exports = function (test) {
       gid: 20
     }, 'hello world\n')
     pack1.finalize()
-    var result1 = new Promise(res=>pack1.pipe(concat(res)))
+    var result1 = new Promise(function (res) {
+      return pack1.pipe(concat(res))
+    })
 
     var pack2 = cpio.pack()
     pack2.file({
@@ -119,10 +121,12 @@ module.exports = function (test) {
       gid: 20
     }, 'hello world\n')
     pack2.finalize()
-    var result2 = new Promise(res=>pack2.pipe(concat(res)))
+    var result2 = new Promise(function (res) {
+      return pack2.pipe(concat(res))
+    })
 
-    Promise.all([result1, result2]).then(results=>{
-      t.deepEqual(...results)
+    Promise.all([result1, result2]).then(function (result1, result2) {
+      t.deepEqual(result1, result2)
     })
   })
 }

--- a/test/pack.js
+++ b/test/pack.js
@@ -125,7 +125,7 @@ module.exports = function (test) {
       return pack2.pipe(concat(res))
     })
 
-    Promise.all([result1, result2]).then(function (result1, result2) {
+    Promise.all([result1, result2]).then(function ([result1, result2]) {
       t.deepEqual(result1, result2)
     })
   })

--- a/test/pack.js
+++ b/test/pack.js
@@ -125,8 +125,8 @@ module.exports = function (test) {
       return pack2.pipe(concat(res))
     })
 
-    Promise.all([result1, result2]).then(function ([result1, result2]) {
-      t.deepEqual(result1, result2)
+    Promise.all([result1, result2]).then(function (results) {
+      t.deepEqual(results[0], results[1])
     })
   })
 }

--- a/test/pack.js
+++ b/test/pack.js
@@ -108,9 +108,6 @@ module.exports = function (test) {
       gid: 20
     }, 'hello world\n')
     pack1.finalize()
-    var result1 = new Promise(function (res) {
-      return pack1.pipe(concat(res))
-    })
 
     var pack2 = cpio.pack()
     pack2.file({
@@ -121,13 +118,13 @@ module.exports = function (test) {
       gid: 20
     }, 'hello world\n')
     pack2.finalize()
-    var result2 = new Promise(function (res) {
-      return pack2.pipe(concat(res))
-    })
 
-    Promise.all([result1, result2]).then(function (results) {
-      t.deepEqual(results[0], results[1])
-    })
+
+    pack1.pipe(concat(function (result1) {
+      pack2.pipe(concat(function (result2) {
+        t.deepEqual(result1, result2)
+      }))
+    }))
   })
 }
 // vim: et:ts=2:sw=2

--- a/test/pack.js
+++ b/test/pack.js
@@ -116,7 +116,7 @@ module.exports = function (test) {
     pack2.file({
       name: 'test.txt',
       mtime: new Date(1419354218000),
-      mode: 0o644,
+      mode: 420,
       uid: 501,
       gid: 20
     }, 'hello world\n')

--- a/test/pack.js
+++ b/test/pack.js
@@ -96,4 +96,34 @@ module.exports = function (test) {
       t.deepEqual(expected, data, 'equivalent cpio')
     }))
   })
+  test('odc: file helper', function (t) {
+    t.plan(1)
+
+    var pack1 = cpio.pack()
+    pack1.entry({
+      name: 'test.txt',
+      mtime: new Date(1419354218000),
+      mode: 33188,
+      uid: 501,
+      gid: 20
+    }, 'hello world\n')
+    pack1.finalize()
+    var result1 = new Promise(res=>pack1.pipe(concat(res)))
+
+    var pack2 = cpio.pack()
+    pack2.file({
+      name: 'test.txt',
+      mtime: new Date(1419354218000),
+      mode: 0o644,
+      uid: 501,
+      gid: 20
+    }, 'hello world\n')
+    pack2.finalize()
+    var result2 = new Promise(res=>pack2.pipe(concat(res)))
+
+    Promise.all([result1, result2]).then(results=>{
+      t.deepEqual(...results)
+    })
+  })
 }
+// vim: et:ts=2:sw=2


### PR DESCRIPTION
I've been tripped up a couple times already by not setting type and having the wrong mode when calling ::entry(). These functions should make Pack a little easier to use directly (as opposed to feeding it from stat).
